### PR TITLE
Handle packaging type 'bundle' just like 'jar'

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ module.exports = function(/*options, callback*/) {
 
     function processJar(dependency, callback) {
       dependency.state = 'processJar';
-      if (dependency.getPackaging() == 'jar') {
+      if (dependency.getPackaging() == 'jar' || dependency.getPackaging() == 'bundle') {
         return resolveJar(dependency, function(err) {
           if (err) {
             return callback(err);


### PR DESCRIPTION
Hi there,

I just started using your fantastic library, but couldn't get it to work for my [dependency](https://repo1.maven.org/maven2/org/apache/pdfbox/pdfbox/1.8.10/pdfbox-1.8.10.pom). I tried to modify the example on your Readme, but it wouldn't correctly set up the classpath.

Turns out some libraries are packaged as 'bundle' instead of 'jar' (which apparently has something to do with how the .jar is built/bundled). See below to get an idea of how I ran into this.

I'd also like to mention that I'm rather new to both Maven and NodeJS, so I have no idea if I'm breaking anything with this PR.
# dependency to be added to package.json

``` js
"java": {
    "dependencies": [
      {
        "groupId": "org.apache.pdfbox",
        "artifactId": "pdfbox",
        "version": "1.8.7"
      }
    ]
  }
```
# index.js

``` js
var java = require('java');
var mvn = require('node-java-maven');

mvn(function(err, mvnResults) {
    if (err) {
        return console.error('could not resolve maven dependencies', err);
    }

    mvnResults.classpath.forEach(function(c) {
        console.log('adding ' + c + ' to classpath');
        java.classpath.push(c);
    });

    var Version = java.import('org.apache.pdfbox.Version');

    console.log(Version.getVersionSync());
});
```
