### PR TITLE
Ability to specify classifier for a dependency.

### DIFF
--- a/lib/dependency.js
+++ b/lib/dependency.js
@@ -33,7 +33,7 @@ Dependency.prototype.getJarPath = function() {
 };
 
 Dependency.prototype.getJarFileName = function() {
-  return this.artifactId + '-' + this.version + '.jar';
+  return this.artifactId + '-' + this.version + ( this.classifier ? '-' + this.classifier : '' ) + '.jar';
 };
 
 Dependency.prototype.getPomFileName = function() {
@@ -146,6 +146,7 @@ Dependency.createFromXmlObject = function(xml, reason) {
   return Dependency.createFromObject({
     groupId: xml.groupId[0],
     artifactId: xml.artifactId[0],
+    classifier: xml.classifier && xml.classifier[0],
     version: xml.version ? xml.version[0] : null,
     scope: xml.scope ? xml.scope[0] : 'compile',
     optional: xml.optional ? (xml.optional[0] == 'true') : false


### PR DESCRIPTION
Was facing an error while using the dependency http://mvnrepository.com/artifact/net.sf.json-lib/json-lib/2.4. The dependency needed a classifier (jdk15) to be set in order to be resolved.
