### PR TITLE
resolveSubstitutions propertyName's values

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,7 +341,10 @@ module.exports = function(/*options, callback*/) {
         return pom.version;
       }
       if(propertyName == 'project.parent.version') {
-        return pom.version;
+          return pom.pomXml.project.parent[0].version[0];
+      }
+      if(propertyName == 'project.parent.groupId') {
+          return pom.pomXml.project.parent[0].groupId[0]
       }
       var property = resolveProperty(propertyName, pom);
       return property instanceof Array ? property.slice(-1) : property;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-java-maven",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Utility for Node's java module to load mvn dependencies.",
   "main": "index.js",
   "bin": {

--- a/test/com.googlecode.netlib-java.netlib-java.json
+++ b/test/com.googlecode.netlib-java.netlib-java.json
@@ -1,0 +1,11 @@
+{
+  "java": {
+    "dependencies": [
+      {
+        "groupId": "com.googlecode.netlib-java",
+        "artifactId": "netlib-java",
+        "version": "1.1"
+      }
+    ]
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,7 @@ describe('maven', function() {
 
   function testJson(jsonPath) {
     it('should pull the maven dependencies for ' + jsonPath, function(done) {
-      this.timeout(60 * 1000);
+      this.timeout(90 * 1000);
       var opts = {
         localRepository: localRepository, 
         packageJsonPath: path.join(__dirname, jsonPath)

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,7 @@ describe('maven', function() {
 
   function testJson(jsonPath) {
     it('should pull the maven dependencies for ' + jsonPath, function(done) {
-      this.timeout(90 * 1000);
+      this.timeout(120 * 1000);
       var opts = {
         localRepository: localRepository, 
         packageJsonPath: path.join(__dirname, jsonPath)

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,7 @@ describe('maven', function() {
   testJson('com.amazonaws_aws-apigateway-importer_1.0.1.json');
   testJson('org.apache.pdfbox_pdfbox_1.8.10.json');
   testJson('org.springframework_spring_2.0.6.json');
+  testJson('com.googlecode.netlib-java.netlib-java.json');
 
   function testJson(jsonPath) {
     it('should pull the maven dependencies for ' + jsonPath, function(done) {


### PR DESCRIPTION
In some dependencies, the groupId and the version are taken from the parent pom and the resolveSubstitution function does not resolve properly when it comes to the value of 'project.parent.version' and 'project.parent.groupId' values.